### PR TITLE
Debug Nix config build failure with Fish

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,8 @@
     ];
   };
   inputs = {
-    # Temporarily lock to 10/20/25
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Pin to working revision before fish 4.2.1 test failures (Nov 8, 2025)
+    nixpkgs.url = "github:NixOS/nixpkgs/f6b44b2401525650256b977063dbcf830f762369";
 
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
The latest nixpkgs-unstable (Nov 15, 2025) has broken fish 4.2.1 tests, which breaks direnv and cascades to home-manager. Pinning to the last known-good revision from Nov 8, 2025 until fish is fixed upstream.