### PR TITLE
Fix flox skills installation to be detected by Claude Code

### DIFF
--- a/modules/home-manager/claude-code.nix
+++ b/modules/home-manager/claude-code.nix
@@ -348,10 +348,40 @@ in
     recursive = true;
   };
 
-  # Flox agentic skills - copy entire skills directory
-  # This automatically includes all current and future skills
-  home.file.".claude/skills/flox" = {
-    source = "${floxAgentic}/flox-plugin/skills";
+  # Flox agentic skills - install each skill at top level
+  # Claude Code scans ~/.claude/skills/*/SKILL.md, not nested directories
+  home.file.".claude/skills/flox-environments" = {
+    source = "${floxAgentic}/flox-plugin/skills/flox-environments";
+    recursive = true;
+  };
+
+  home.file.".claude/skills/flox-services" = {
+    source = "${floxAgentic}/flox-plugin/skills/flox-services";
+    recursive = true;
+  };
+
+  home.file.".claude/skills/flox-builds" = {
+    source = "${floxAgentic}/flox-plugin/skills/flox-builds";
+    recursive = true;
+  };
+
+  home.file.".claude/skills/flox-containers" = {
+    source = "${floxAgentic}/flox-plugin/skills/flox-containers";
+    recursive = true;
+  };
+
+  home.file.".claude/skills/flox-publish" = {
+    source = "${floxAgentic}/flox-plugin/skills/flox-publish";
+    recursive = true;
+  };
+
+  home.file.".claude/skills/flox-sharing" = {
+    source = "${floxAgentic}/flox-plugin/skills/flox-sharing";
+    recursive = true;
+  };
+
+  home.file.".claude/skills/flox-cuda" = {
+    source = "${floxAgentic}/flox-plugin/skills/flox-cuda";
     recursive = true;
   };
 }


### PR DESCRIPTION
The previous 'simplification' nested skills under ~/.claude/skills/flox/ which prevented Claude Code from detecting them (it scans */SKILL.md).

Reverting to individual skill installation at the top level so each skill is properly detected at ~/.claude/skills/flox-*/SKILL.md