### PR TITLE
Disable auto compact in Claude config

### DIFF
--- a/modules/home-manager/claude-code.nix
+++ b/modules/home-manager/claude-code.nix
@@ -90,6 +90,7 @@ in
         ];
       };
       interactiveMode = true;
+      autoCompact = false;
 
       # Custom status line configuration
       statusLine = {


### PR DESCRIPTION
Add autoCompact = false to the Claude settings to prevent automatic conversation history compaction. This gives the user more control over when context is compacted.